### PR TITLE
Fixed the issue of play/pause button in chat video in firefox

### DIFF
--- a/app/scripts/events.js
+++ b/app/scripts/events.js
@@ -973,7 +973,7 @@ define([
             $workspace.on('click', '.j-videoPlayer', function(e) {
                 var video = e.target;
 
-                if (!video.dataset.source) return false;
+                if (!video.dataset.source) return true;
 
                 video.src = video.dataset.source;
                 video.preload = 'metadata';


### PR DESCRIPTION
*Make sure that you wrote the tests for your proposed changes and the existing test was success.*

**Made/Proposed changes:**
*(Don’t use general words, describe changes in details)*

- Changed the return to true to make it functional in firefox. If it returns false, event is terminated in firefox. False was preventing play/pause event in firefox.

**How should this be manually tested?**
Post video in chat, open firefox browser and go to chat message. Click on play button, again click on pause button. It wont work in firefox and some other browser as well because it returns false and event reverted. This works well in chrome with no issues. 

**Does the documentation need an update?**
No